### PR TITLE
Fix timezone issue

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -76,7 +76,7 @@ export const getTodayAsStartEndDates = (): StartEndDates => {
  */
 export const getTimezone = (date: Date): string => {
   const tzoff = date.getTimezoneOffset();
-  const h = Math.floor(tzoff / 60);
+  const h = Math.floor(Math.abs(tzoff) / 60);
   const m = tzoff % 60;
   return (tzoff < 0 ? '+' : '-') + h.toString().padStart(2, '0') + m.toString().padStart(2, '0');
 }


### PR DESCRIPTION
Now negative timezone offsets no longer result in `+-number`

Without this, the URLs would have `to=2023-11-22T23:59:59.999+-100` as a query parameter.
This happens because, for example, a timezone offset of `-60` would result in `tzoff = -1`.
It also wasn't being padded, because `-1` already is 2 characters.

All of this resulted in a 400 from Harvest and should fix the error mentioned in some closed issues.